### PR TITLE
Update 0400-trackers_and_adservers.txt

### DIFF
--- a/build/0400-trackers_and_adservers.txt
+++ b/build/0400-trackers_and_adservers.txt
@@ -109,7 +109,6 @@
 ||imprsngl.info^
 ||syndication.trafficreps.com^
 ||trafficshop.com^
-||trib.al^
 !!!
 !!! elemelrejtes
 !!! az ilyen formaju szabalyok a reklam


### PR DESCRIPTION
A trib.al nem reklámoldal, hanem egy link rövidítő szolgáltatás, így ennek tiltása sok értelmes weboldalt is kiszűr. Javaslom a törlését.
