### PR TITLE
Add filters for hwsw.hu

### DIFF
--- a/build/0100-websites.txt
+++ b/build/0100-websites.txt
@@ -350,6 +350,7 @@ hwsw.hu##DIV[class="billboard"]
 hwsw.hu##DIV[class="cikkszovegakcio"]
 hwsw.hu##DIV[id*="hirdetes"]
 hwsw.hu##[class*="hirdetes"]
+hwsw.hu##div > a[href^="https://goo.gl/"]
 hwsw.hu/images/*_HWSW_*.*
 ||hwsw.hu/images*bg_*.*
 hwsw.hu/images/bg-*.*


### PR DESCRIPTION
HWSW uses goo.gl to hide it's ad links. This filters the background ads on-click and the "see-through" ad boxes on the top.