### PR TITLE
Új cookie-notice szűrő

### DIFF
--- a/build/0100-websites.txt
+++ b/build/0100-websites.txt
@@ -3,6 +3,10 @@
 !                       Weboldalak                                       ! 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+!
+24.hu##[class*="banner-"]
+24.hu##.cc_container--open.cc_container.cc_gccp
+!
 ||sher.*.hu^
 ||rehs.*.hu^
 index.hu##[class*="adblokk"]

--- a/build/0200-singlerules.txt
+++ b/build/0200-singlerules.txt
@@ -3,7 +3,6 @@
 !!!!    Egyszabalyos oldalak          !!!!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-24.hu##[class*="banner-"]
 5mp.eu##DIV[id="alsobox"]
 5perc.es##[class*="banner"]
 CegMarketing.hu/banner*

--- a/hufilter-minuseasylist.txt
+++ b/hufilter-minuseasylist.txt
@@ -6,7 +6,7 @@
 !Licence: CC-BY, see http://creativecommons.org/licenses/by/4.0/
 !Title: hufilter
 !Expires: 16 hours
-!Version: 201706110857
+!Version: 201706171211
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Magyar Adblock Plus szurolista
 ! 
@@ -58,6 +58,10 @@
 !                       Weboldalak                                       ! 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+!
+24.hu##[class*="banner-"]
+24.hu##.cc_container--open.cc_container.cc_gccp
+!
 ||sher.*.hu^
 ||rehs.*.hu^
 index.hu##[class*="adblokk"]
@@ -1160,7 +1164,6 @@ budapestpark.hu##.banner_main_page_wrapper
 !!!!    Egyszabalyos oldalak          !!!!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-24.hu##[class*="banner-"]
 5mp.eu##DIV[id="alsobox"]
 5perc.es##[class*="banner"]
 CegMarketing.hu/banner*

--- a/hufilter.txt
+++ b/hufilter.txt
@@ -6,7 +6,7 @@
 !Licence: CC-BY, see http://creativecommons.org/licenses/by/4.0/
 !Title: hufilter
 !Expires: 16 hours
-!Version: 201706110857
+!Version: 201706171211
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Magyar Adblock Plus szurolista
 ! 
@@ -58,6 +58,10 @@
 !                       Weboldalak                                       ! 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+!
+24.hu##[class*="banner-"]
+24.hu##.cc_container--open.cc_container.cc_gccp
+!
 ||sher.*.hu^
 ||rehs.*.hu^
 index.hu##[class*="adblokk"]
@@ -1160,7 +1164,6 @@ budapestpark.hu##.banner_main_page_wrapper
 !!!!    Egyszabalyos oldalak          !!!!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-24.hu##[class*="banner-"]
 5mp.eu##DIV[id="alsobox"]
 5perc.es##[class*="banner"]
 CegMarketing.hu/banner*


### PR DESCRIPTION
A 24.hu oldal már szerepelt a 0200-singlerules.txt-ben, a régi szabály is átkerült a 0100-websites.txt-be