### PR TITLE
hwsw.hu szűrők

### DIFF
--- a/build/0100-websites.txt
+++ b/build/0100-websites.txt
@@ -363,20 +363,11 @@ hwsw.hu##DIV[class="billboard"]
 hwsw.hu##DIV[class="cikkszovegakcio"]
 hwsw.hu##DIV[id*="hirdetes"]
 hwsw.hu##[class*="hirdetes"]
-hwsw.hu##div > a[href^="https://goo.gl/"]
-hwsw.hu##div > a[href^="http://tinyurl.hu/"]
-hwsw.hu##div > a[href^="http://bit.ly/"]
-hwsw.hu/images/*_HWSW_*.*
-||hwsw.hu/images*bg_*.*
-||hwsw.hu/images/bodybgs/*$image
-hwsw.hu/images/bg-*.*
-hwsw.hu/images/nops/*
-hwsw.hu/images/*-prodterv.*
-hwsw.hu/*_skin*hwsw.*
-hwsw.hu/images/*-*tab.*
-hwsw.hu/images/*_hatter_*.*
 hwsw.hu###cookiealert
-hwsw.hu,~m.hwsw.hu,~forum.hwsw.hu,~rendezveny.hwsw.hu##body:style(padding-top: 0px !important;background-color: #777 !important;)
+||hwsw.hu/images/bodybgs/*$image
+hwsw.hu##body > div > a[target="_blank"]
+hwsw.hu##body[style*="padding-top"]:style(padding-top: 0px !important; background-color: #777 !important;)
+!hwsw.hu##.adomany
 !
 ||harmonet.hu/*hirdetes
 harmonet.hu##DIV[id*="banner"]


### PR DESCRIPTION
Remélhetőleg ez a frissítés véget vet a hwswsekkel vívott linkrövidítős csatának.
Kiszedtem a felesleges már nem használt filtereket, és az URL-től függetlenül kiszűrtem a full-page ad boxokat.

Ízlés szerint a hwsw.hu##.adomany szűrőt lehet aktiválni, ami eltünteti a cikk listából a szponzorált tartalmakat.