### PR TITLE
Adblock blockers

### DIFF
--- a/build/0100-websites.txt
+++ b/build/0100-websites.txt
@@ -971,6 +971,8 @@ oprend.hu##[class*="ad-warning"]
 !profession.hu###jqi
 !profession.hu###jqifade
 profession.hu###twister-banner
+||stat.profession.hu/static/assets/images/prize-game*$image
+www.profession.hu###newsletter_footer
 !
 infopapa.hu##.banner_300_600
 infopapa.hu##.banner_468_120

--- a/build/0100-websites.txt
+++ b/build/0100-websites.txt
@@ -86,6 +86,8 @@ totalcar.hu##.totalkarWidget
 totalcar.hu##.joautok-iframe-cikk-torzs
 totalcar.hu##.cikk-vegi-ajanlo-reklamok-container
 ||totalcar.hu/assets/*adbd*
+totalcar.hu##body > script:has-text(window.onload = window.onfocus)
+totalcar.hu##body > section:last-of-type
 !
 ||chat.hu/Client/banner
 ||chat.hu/imgadverts*

--- a/build/0100-websites.txt
+++ b/build/0100-websites.txt
@@ -89,6 +89,9 @@ totalcar.hu##.cikk-vegi-ajanlo-reklamok-container
 totalcar.hu##body > script:has-text(window.onload = window.onfocus)
 totalcar.hu##body > section:last-of-type
 !
+totalbike.hu##body > script:has-text(window.onload = window.onfocus)
+totalbike.hu##body > section:last-of-type
+!
 ||chat.hu/Client/banner
 ||chat.hu/imgadverts*
 chat.hu##[class*="hirdetes"]

--- a/build/0100-websites.txt
+++ b/build/0100-websites.txt
@@ -312,6 +312,8 @@ gyakorikerdesek.hu/pic/bannerek/
 gyakorikerdesek.hu##div.reklam_jobbra
 gyakorikerdesek.hu##td.txtcenter:-abp-has(> script + ins)
 gyakorikerdesek.hu##td[style="width: 10px;"]:empty
+gyakorikerdesek.hu##.rltdwidget
+gyakorikerdesek.hu##[href^="https://www.webminute.hu"]
 !
 ||klubradio.hu/data/files/banner
 klubradio.hu##DIV[id*="banner"]

--- a/build/0100-websites.txt
+++ b/build/0100-websites.txt
@@ -631,6 +631,8 @@ divany.hu##.cikk-vegi-ajanlo-reklamok
 divany.hu##iframe
 divany.hu##body > script:has-text(window.onload = window.onfocus)
 divany.hu##body > section:last-of-type
+divany.hu##.cikk-halfpage.t-article-container_sidebar > div:first-child
+divany.hu##.rovat-halfpage.t-rovat-container_sidebar > div:first-child
 !
 ! HáziPatika
 hazipatika.com##TD[id*="l_sponsor"]

--- a/build/0100-websites.txt
+++ b/build/0100-websites.txt
@@ -629,6 +629,8 @@ divany.hu##[id*="hirdetes"]
 divany.hu##.tctk
 divany.hu##.cikk-vegi-ajanlo-reklamok
 divany.hu##iframe
+divany.hu##body > script:has-text(window.onload = window.onfocus)
+divany.hu##body > section:last-of-type
 !
 ! HáziPatika
 hazipatika.com##TD[id*="l_sponsor"]

--- a/build/0200-singlerules.txt
+++ b/build/0200-singlerules.txt
@@ -4,6 +4,7 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !
 !
+||app.livechatoo.com
 cegmarketing.hu/banner*
 babaszoba.hu##[class*="advert"]
 bankmonitor.hu##.askUsSlide

--- a/build/0400-other.txt
+++ b/build/0400-other.txt
@@ -50,10 +50,12 @@ rp5.ru#@#[id^="aswift_"]
 !
 www.glassdoor.com###HardsellOverlay
 www.glassdoor.com###PageBot
+www.glassdoor.com###CovidInfoBanner
 ||glassdoor.com/app/static/js/dist/gd-user-hardsell-overlay*^
 ||glassdoor.com/app/static/js/gd-ei-upsell*^
 ||glassdoor.com/app/static/js/gd-fj-ads-init*^
 ||glassdoor.com/app/static/js/gd-ei-employer-targeting*^
+||glassdoor.com/app/static/js/dist/gd-covid19Banner*^
 !
 /gemius.js^
 /gemius.min.js^

--- a/build/0400-other.txt
+++ b/build/0400-other.txt
@@ -48,6 +48,13 @@ rp5.ru#@#[id^="aswift_"]
 ! GH#174
 !hu##.jwplayer
 !
+www.glassdoor.com###HardsellOverlay
+www.glassdoor.com###PageBot
+||glassdoor.com/app/static/js/dist/gd-user-hardsell-overlay*^
+||glassdoor.com/app/static/js/gd-ei-upsell*^
+||glassdoor.com/app/static/js/gd-fj-ads-init*^
+||glassdoor.com/app/static/js/gd-ei-employer-targeting*^
+!
 /gemius.js^
 /gemius.min.js^
 /xgemius.js^


### PR DESCRIPTION
- Resolve #195, block inline script adblocker on totalcar, totalbike and velvet
- Resolve #193, block gyakorikerdesek.hu fallback ad
- block velvet.hu fallback ad
- block profession.hu ad-letter, and data harvesting campaigns
- block furbify.hu lead generator
- block glassdoor.com login wall
- block glassdoor.com covid spam

Tested on uBlock Origin on Firefox (Gecko-based) and Edgium (Chromium-based)