### PR TITLE
removed femina.hu false positive rule

### DIFF
--- a/dev/ads.txt
+++ b/dev/ads.txt
@@ -565,7 +565,6 @@ femina.hu##[class*="kepeslinkes"]
 femina.hu##.doboz_harmados
 femina.hu#@#[class="goAdverticum"]
 femina.hu#?#.szelso-jobb > div:-abp-has(> a)
-femina.hu#?#.cikk-torzs [data-miniapp-id]:-abp-has(.lapozgato-ajanlo)
 femina.hu#?#.cikk-torzs [data-miniapp-id]:-abp-has(.femina-shop-ajanlo-slider-hirdetes)
 !
 femcafe.hu##[class*="-adv"]

--- a/hufilter-abp.txt
+++ b/hufilter-abp.txt
@@ -1,8 +1,8 @@
 [Adblock Plus 2.0]
-! Checksum: OtM5wqJe82Aa9XYVUBhkGQ
-! Version: 202101082022
+! Checksum: yTwI6XlOiY68gjcLBbtRwA
+! Version: 202101101216
 ! Title: hufilter
-! Last modified: 08 Jan 2021 20:22 UTC
+! Last modified: 10 Jan 2021 12:16 UTC
 ! Expires: 1 days (update frequency)
 ! Homepage: https://github.com/hufilter/hufilter/wiki
 ! Licence: CC-BY, see http://creativecommons.org/licenses/by/4.0/
@@ -591,7 +591,6 @@ femina.hu##[class*="kepeslinkes"]
 femina.hu##.doboz_harmados
 femina.hu#@#[class="goAdverticum"]
 femina.hu#?#.szelso-jobb > div:-abp-has(> a)
-femina.hu#?#.cikk-torzs [data-miniapp-id]:-abp-has(.lapozgato-ajanlo)
 femina.hu#?#.cikk-torzs [data-miniapp-id]:-abp-has(.femina-shop-ajanlo-slider-hirdetes)
 !
 femcafe.hu##[class*="-adv"]

--- a/hufilter-adguard.txt
+++ b/hufilter-adguard.txt
@@ -585,7 +585,6 @@ femina.hu##[class*="kepeslinkes"]
 femina.hu##.doboz_harmados
 femina.hu#@#[class="goAdverticum"]
 femina.hu#?#.szelso-jobb > div:-abp-has(> a)
-femina.hu#?#.cikk-torzs [data-miniapp-id]:-abp-has(.lapozgato-ajanlo)
 femina.hu#?#.cikk-torzs [data-miniapp-id]:-abp-has(.femina-shop-ajanlo-slider-hirdetes)
 !
 femcafe.hu##[class*="-adv"]

--- a/hufilter-ublock.txt
+++ b/hufilter-ublock.txt
@@ -1,7 +1,7 @@
-! Checksum: AhTARhSdW7Z/epfBOEyy8A
-! Version: 202101082022
+! Checksum: oZf2FqRA3PhevKZZA77bOA
+! Version: 202101101216
 ! Title: hufilter
-! Last modified: 08 Jan 2021 20:22 UTC
+! Last modified: 10 Jan 2021 12:16 UTC
 ! Expires: 1 days (update frequency)
 ! Homepage: https://github.com/hufilter/hufilter/wiki
 ! Licence: CC-BY, see http://creativecommons.org/licenses/by/4.0/
@@ -590,7 +590,6 @@ femina.hu##[class*="kepeslinkes"]
 femina.hu##.doboz_harmados
 femina.hu#@#[class="goAdverticum"]
 femina.hu#?#.szelso-jobb > div:-abp-has(> a)
-femina.hu#?#.cikk-torzs [data-miniapp-id]:-abp-has(.lapozgato-ajanlo)
 femina.hu#?#.cikk-torzs [data-miniapp-id]:-abp-has(.femina-shop-ajanlo-slider-hirdetes)
 !
 femcafe.hu##[class*="-adv"]

--- a/hufilter.txt
+++ b/hufilter.txt
@@ -1,8 +1,8 @@
 [Adblock Plus 2.0]
-! Checksum: OtM5wqJe82Aa9XYVUBhkGQ
-! Version: 202101082022
+! Checksum: yTwI6XlOiY68gjcLBbtRwA
+! Version: 202101101216
 ! Title: hufilter
-! Last modified: 08 Jan 2021 20:22 UTC
+! Last modified: 10 Jan 2021 12:16 UTC
 ! Expires: 1 days (update frequency)
 ! Homepage: https://github.com/hufilter/hufilter/wiki
 ! Licence: CC-BY, see http://creativecommons.org/licenses/by/4.0/
@@ -591,7 +591,6 @@ femina.hu##[class*="kepeslinkes"]
 femina.hu##.doboz_harmados
 femina.hu#@#[class="goAdverticum"]
 femina.hu#?#.szelso-jobb > div:-abp-has(> a)
-femina.hu#?#.cikk-torzs [data-miniapp-id]:-abp-has(.lapozgato-ajanlo)
 femina.hu#?#.cikk-torzs [data-miniapp-id]:-abp-has(.femina-shop-ajanlo-slider-hirdetes)
 !
 femcafe.hu##[class*="-adv"]


### PR DESCRIPTION
Töröltem egy femina.hu kozmetikai szűrőt, ami nem reklámokat tüntetett el, hanem egyes cikkek végén "kiemelt" cikkajánlókat.

Bővebben ...
Minden femina.hu cikk végén van egy "OLVASD EL EZT IS!" (sárga hátterű) doboz alatt egy cikkajánló lista.
De egyes cikkek végén (pl. https://femina.hu/vilagsztar/robin-williams-jumanji/) a cikk tartalmának vége és a megosztási sáv (amiben a levelezés, viber, pinterest és twitter ikonok vannak) között megjelenik egy konkrét femina.hu cikk ajánlója is, ami végülis a cikk részét képezi, nem véletlenül (algoritmus/kód által), hanem a cikk szerzője/szerkesztője által kerül kiválasztásra.
Eme cikkajánlókat tüntette el az a kozmetikai szűrő, amit eme PR eltávolít a listából.

A femina.hu címlapjáról kiindulva megnéztem pár tucat cikket, kiválasztottam ezek közül azokat, amelyekhez tartozik ilyen kiemelt cikkajánló és megnéztem őket a kérdéses kozmetikai filterrel és anélkül is. Minden esetben csak eme kiemelt cikkajánlót befolyásolta a filter, azaz az eltávolításával nem jelentek meg addig kiszűrt reklámok, stb.