### PR TITLE
ncore.cc domain change to ncore.pro

### DIFF
--- a/dev/ads.txt
+++ b/dev/ads.txt
@@ -1593,7 +1593,7 @@ agrarszektor.hu##div#ajanlo
 !
 travelo.hu##div.facebook-layer-box
 !
-ncore.cc##.banner
+ncore.pro##.banner
 !
 dehir.hu##.totop
 dehir.hu##.slidingBanner

--- a/dev/ublock-specific.txt
+++ b/dev/ublock-specific.txt
@@ -123,5 +123,5 @@ hetek.hu##[class="modal-backdrop fade show"]
 @@||meszotar.hu/scripts/advertising.js
 /js/vendor/blockadblock.js^$domain=szineshir.net|zoldmano.info
 ||freewaresoftwarenews.blogspot.$first-party,inline-script
-ncore.cc##^#x-pop
-ncore.cc##^.container-in > script:last-of-type
+ncore.pro##^#x-pop
+ncore.pro##^.container-in > script:last-of-type


### PR DESCRIPTION
Megváltozott az nCore címe ncore.cc-ről ncore.pro-ra. Az ncore.cc már csak átírányít az új domainre. A domainváltozás miatt eltörtek az eddigi szabályok, ezt javítottam.

Forrás: [https://facebook.com/ncoreofficial/posts/4902705349804548](https://facebook.com/ncoreofficial/posts/4902705349804548)