### PR TITLE
Build Pi-hole specific list with proper header

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -35,5 +35,12 @@
     "dns": true,
     "header": "dns.txt",
     "sections": ["ads.txt", "annoyances.txt", "trackers.txt", "other.txt"]
+  },
+  {
+    "output": "hufilter-pihole.txt",
+    "title": "Hufilter Pi-hole",
+    "dns": true,
+    "header": "pihole.txt",
+    "sections": ["ads.txt", "annoyances.txt", "trackers.txt", "other.txt"]
   }
 ]

--- a/sections/headers/pihole.txt
+++ b/sections/headers/pihole.txt
@@ -1,0 +1,25 @@
+# Checksum: #CHECKSUM#
+# Version: #VERSION#
+# Title: #TITLE#
+# Last modified: #LAST_MODIFIED#
+# Expires: 7 days (update frequency)
+# Homepage: https://github.com/hufilter/hufilter/wiki
+# Licence: CC-BY, see https://creativecommons.org/licenses/by/4.0/
+#
+#---------------------------------------------------------------------------#
+#-------------- Description, Terms of use, Issue management ----------------#
+#---------------------------------------------------------------------------#
+# Hufilter - The Hungarian Adblock List
+# Author: Hufilter Team (https://github.com/hufilter)
+#
+# Please report any unblocked adverts or problems in the GitHub issue tracker.
+# About filter policy and usage terms please see the homepage above.
+# By using the filter you automatically accept the terms of use.
+#
+# Kerjuk, jelentsd a nem blokkolt hirdeteseket vagy a hibakat a GitHub issue trackerben.
+# A szuresi iranyelveket, felhasznalasi felteteleket lasd a fenti honlapon.
+# A szuro hasznalataval automatikusan elfogadod a felhasznalasi felteteleket.
+#
+# GitHub issues: https://github.com/hufilter/hufilter-dev/issues
+# GitHub pull requests: https://github.com/hufilter/hufilter-dev/pulls
+#


### PR DESCRIPTION
I've added some lines to the `filters.json` file and a new `pihole.txt` file so the automatic build script will deploy a Pi-hole specific build with the same header as the other lists. This closes the the #266 issue.