### PR TITLE
idokep.hu fix

### DIFF
--- a/sections/ads.txt
+++ b/sections/ads.txt
@@ -615,7 +615,7 @@ hwsw.hu##body > div > a[target="_blank"]
 hwsw.hu##DIV[id*="hirdetes"]
 idokep.hu##[class*="hird_"]
 idokep.hu##[class*="hird-"]
-idokep.hu##a[href*="gemius"]
+idokep.hu##a[data-bs-content*="(hirdetés)"]
 ilovebalaton.hu##[class*=" ad"]
 indavideo.hu##.topAdv
 indavideo.hu##[class*="billboard"]


### PR DESCRIPTION
A kijavított sor az egyik korábbi PR-emben volt, sajnos nem elég pontos. A hirdetések nem mindig a Gemiusra mutatnak (pl. amikor a Viber csatornájukat hirdetik), viszont megfigyelés alapján a "(hirdetés)" mindig a popup szöveg része.