### PR TITLE
fix #312 mindmegette.hu

### DIFF
--- a/sections/adguard-specific.txt
+++ b/sections/adguard-specific.txt
@@ -53,6 +53,8 @@ magyarhang.org,hang.hu#%#//scriptlet('abort-current-inline-script', 'document.ge
 ! https://github.com/AdguardTeam/AdguardFilters/issues/128532
 magyarorszag.hu#%#//scriptlet('set-cookie', 'cookies_ok', '1')
 mandiner.hu#%#//scriptlet('remove-class', 'modal-open', 'body', 'stay')
+! https://github.com/hufilter/hufilter-dev/issues/312
+mindmegette.hu#%#//scriptlet('remove-attr', 'href', '[href*="ad.adverticum.net"]')
 ! https://github.com/hufilter/hufilter/issues/8
 napiszar.com#%#//scriptlet('abort-current-inline-script', 'document.createElement', 'setTimeout')
 pcworld.hu#%#//scriptlet('remove-class', 'have-ad', 'body')

--- a/sections/ads.txt
+++ b/sections/ads.txt
@@ -34,7 +34,7 @@
 ##[class*="GoogleAds"]
 ##[class*="overlayBg"]
 ##[data-campaign-name^="ads"]
-##[href*="ad.adverticum.net"]:not(a)
+##[href*="ad.adverticum.net"]
 ##[href*="kuponmania.hu"]
 ##[id*="google_ads"]
 ##[id*="GoogleAds"]

--- a/sections/ads.txt
+++ b/sections/ads.txt
@@ -843,6 +843,8 @@ mindenkilapja.hu##[class*="advert"]
 mindmegette.hu##.billboard-cikk
 mindmegette.hu##.hir-fekvo
 mindmegette.hu##[class*="ads_box"]
+! https://github.com/hufilter/hufilter-dev/issues/312
+mindmegette.hu#@#[href*="ad.adverticum.net"]
 mindmegette.hu###ad-image-big
 mindmegette.hu###fadeandscale
 mindmegette.hu###fadeandscale_background

--- a/sections/ads.txt
+++ b/sections/ads.txt
@@ -34,7 +34,7 @@
 ##[class*="GoogleAds"]
 ##[class*="overlayBg"]
 ##[data-campaign-name^="ads"]
-##[href*="ad.adverticum.net"]
+##[href*="ad.adverticum.net"]:not(a)
 ##[href*="kuponmania.hu"]
 ##[id*="google_ads"]
 ##[id*="GoogleAds"]
@@ -851,6 +851,8 @@ mindmegette.hu###sidebar_ads_box_2
 mindmegette.hu##DIV[class="billboard fr"]
 mindmegette.hu##DIV[class="fej-elso-sor cf"]
 mindmegette.hu##DIV[id*="-ad-"]
+! https://github.com/hufilter/hufilter-dev/issues/312
+mindmegette.hu#@#a[href*="adverticum.net"]
 mitortent.hu##[class^="adv"]
 mixonline.hu##[class*="banner"]
 mkbnetbankar.hu##.x-marketing

--- a/sections/ads.txt
+++ b/sections/ads.txt
@@ -853,8 +853,6 @@ mindmegette.hu###sidebar_ads_box_2
 mindmegette.hu##DIV[class="billboard fr"]
 mindmegette.hu##DIV[class="fej-elso-sor cf"]
 mindmegette.hu##DIV[id*="-ad-"]
-! https://github.com/hufilter/hufilter-dev/issues/312
-mindmegette.hu#@#a[href*="adverticum.net"]
 mitortent.hu##[class^="adv"]
 mixonline.hu##[class*="banner"]
 mkbnetbankar.hu##.x-marketing

--- a/sections/ublock-specific.txt
+++ b/sections/ublock-specific.txt
@@ -51,6 +51,8 @@ magyarhang.org,hang.hu##+js(acis, document.getElementById, ai_run_)
 magyarorszag.hu##+js(rc, bottom-l, body, stay)
 magyarorszag.hu##+js(rc, bottom-s, body, stay)
 mandiner.hu##+js(rc, modal-open, body, stay)
+! https://github.com/hufilter/hufilter-dev/issues/312
+mindmegette.hu##+js(remove-attr, href, [href*="ad.adverticum.net"])
 napiszar.com##^script[data-cfasync="false"]
 ! https://github.com/hufilter/hufilter/issues/8
 napiszar.com##+js(acis, document.createElement, setTimeout)


### PR DESCRIPTION
Ld. #312

A [`##a[href*="adverticum.net"]`](https://github.com/hufilter/hufilter-dev/blob/b3237543536f343cf42243a8ef2820174a07f8c0/sections/ads.txt#L79) miatt a `##[href*="ad.adverticum.net"]:not(a)` egy teljesen jó megoldás, de `mindmegette.hu#@#[href*="ad.adverticum.net"]` + `mindmegette.hu##[href*="ad.adverticum.net"]:not(a)` is működne (itt nem is kell a második, de jobb biztosra menni).

Closes https://github.com/hufilter/hufilter-dev/issues/312