### PR TITLE
Disable Dependabot temporarily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,8 @@ updates:
       interval: "daily"
 
   # Maintain dependencies for npm
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"
+  # TODO: Re-enable after we updated the tooling
+  # - package-ecosystem: "npm"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "daily"


### PR DESCRIPTION
I will soon change the tooling to AGLint and a new Filter Compiler, until then I will temporarily disable Dependabot for NPM packages, since I no longer plan to upgrade the current packages for the legacy tooling, so Dependabot will only make noise in the repo.