### PR TITLE
M: Fix rule separator

### DIFF
--- a/sections/ads.txt
+++ b/sections/ads.txt
@@ -107,7 +107,7 @@ adozona.hu##.big_badge
 adozona.hu##[class*="ads"]
 adozona.hu###g0
 agrarszektor.hu###ajanlo
-agroinform.hu##.ez-egy-dc-doboz:-abp-has(> .double_click_doboz)
+agroinform.hu#?#.ez-egy-dc-doboz:-abp-has(> .double_click_doboz)
 alapjarat.hu###alapjarat_cikk_fekvo_1
 alapjarat.hu##div.header + .clearfix + .clearfix
 alfahir.hu###block-block-16


### PR DESCRIPTION
Invalid syntax at `agroinform.hu##.ez-egy-dc-doboz:-abp-has(> .double_click_doboz)`