### PR TITLE
Telex.hu támogass banner elrejtése

### DIFF
--- a/sections/ads.txt
+++ b/sections/ads.txt
@@ -1043,6 +1043,7 @@ telex.hu##.banner-bottom
 telex.hu##.recommendation.recommendation--out
 telex.hu##.recommendation.recommendation--pr
 telex.hu##.title-section__sponsored
+telex.hu##SPAN[class="modal--umbrella__container"]
 teltlanyok.com##[id^="adchange"]
 terhesferfi.hu##div.banner
 termalfurdo.hu##.kiemelttartalombox_feher


### PR DESCRIPTION
Korábban a DIV-et el kellett távolítanom egy korábbi szabály hozzáadásánál, a SPAN-al is ez a helyzet? Van erről több részlet a repóban? A README, CONTRIBUTING és a sections/README-ben nem látok erre egyértelmű szabályt, csak hogy olvassak el 3 külső doksit, ami órákig tartana. Köszi