### PR TITLE
Block foodora ads

### DIFF
--- a/sections/ads.txt
+++ b/sections/ads.txt
@@ -373,6 +373,7 @@ figyelo.hu##[class*="banner"]
 filmoldal.hu##div[class*="reklam"]
 ! https://github.com/hufilter/hufilter/issues/11
 filmvilag.me##[href^="https://rosszlanyok.hu/"]
+foodora.hu##.partnership-ads
 forbes.hu##div[id^="forbesad"]
 forbes.hu##p + [class*="-bekezdes-utan-"]
 forum.index.hu###ot2015


### PR DESCRIPTION
Foodora added showing "sponsors" on their tracking page when you order something
![image](https://github.com/user-attachments/assets/f60dac69-9b21-40ac-8263-010a691ff104)

This PR removes those ads
![image](https://github.com/user-attachments/assets/7bf23341-7e0f-4af3-89cf-8b1d673a4c4a)
