### PR TITLE
Apply checksum after removing empty lines instead of before

### DIFF
--- a/assets/scripts/build.js
+++ b/assets/scripts/build.js
@@ -60,6 +60,13 @@ buildFilters = async () => {
             : domains
         ).join("\n");
       }
+      // Remove empty lines
+      const strippedFilters =
+        content
+          .split(/\r?\n/)
+          .filter((line) => line.replace("!", "").trim().length > 0)
+          .join("\n") +
+        "\n";
       // Header attributes
       if (headerContent.length) {
         // Versions
@@ -67,17 +74,10 @@ buildFilters = async () => {
         headerContent = headerContent.replace(/#LAST_MODIFIED#/, lastModified);
         headerContent = headerContent.replace(/#TITLE#/, filter.title || "hufilter");
         // Checksum
-        const checksum = calculateChecksum(headerContent + content);
+        const checksum = await calculateChecksum(headerContent + strippedFilters);
         headerContent = headerContent.replace(/#CHECKSUM#/, checksum);
       }
-      // Remove empty lines
-      const fileContent =
-        headerContent +
-        content
-          .split(/\r?\n/)
-          .filter((line) => line.replace("!", "").trim().length > 0)
-          .join("\n") +
-        "\n";
+      const fileContent = headerContent + strippedFilters;
       // Write output
       await fs.writeFile(
         path.join(__dirname, `../../dist/${filter.output}`),


### PR DESCRIPTION
I noticed the checksums on these lists were impossible to reproduce. After digging through the build script, it looks like the file has some empty newlines removed after the checksum is calculated. That means the checksum can only be reproduced if the empty newlines are added back again, but it's impossible for clients to know where to put those newlines. If clients cannot reproduce the checksum, they cannot use it to verify the integrity of the published files.

I reordered the build steps so that the checksums are calculated after removing the empty newlines. With that change, all that is required to reproduce the checksum is to remove the `! Checksum: ...\n` line and take the base64-encoded md5 hash of the rest of the list, which is in-line with how other lists' checksums can be verified.