### PR TITLE
[POC] Automated rule checking

### DIFF
--- a/assets/scripts/check.js
+++ b/assets/scripts/check.js
@@ -1,0 +1,122 @@
+import { FilterListParser } from "@adguard/agtree/parser";
+import fs from "fs/promises";
+import path from "path";
+import { chromium } from "playwright";
+
+const filterPath = path.join(process.cwd(), "dist", "hufilter.txt");
+
+const parseFilterList = async (filePath) => {
+  try {
+    console.log(`Parsing filter list from ${filePath}...`);
+    const content = await fs.readFile(filePath, "utf-8");
+    const ast = FilterListParser.parse(content);
+
+    const rules = ast.children.filter((rule) => rule.category === "Cosmetic");
+
+    console.log("Filter list parsed successfully.");
+    console.log(`Total rules: ${ast.children.length}`);
+    console.log(`Cosmetic rules: ${rules.length}`);
+
+    return rules;
+  } catch (error) {
+    console.error("Error parsing filter list:", error);
+    throw error;
+  }
+};
+
+const rules = await parseFilterList(filterPath);
+const groupedRules = {};
+
+for (const rule of rules) {
+  const domains = rule.domains.children
+    .filter((domain) => domain.value !== "hu")
+    .map((domain) => domain.value);
+  for (const domain of domains) {
+    groupedRules[domain] ??= [];
+    groupedRules[domain].push({
+      rule: rule.raws.text,
+      selector: rule.body.selectorList.value,
+    });
+  }
+}
+
+console.log(`Total unique domains: ${Object.keys(groupedRules).length}`);
+
+// Sort groupedRules alphabetically.
+const sortedGroupedRules = Object.keys(groupedRules)
+  .sort()
+  .reduce((acc, key) => {
+    acc[key] = groupedRules[key];
+    return acc;
+  }, {});
+
+const browser = await chromium.launch({ headless: true });
+const context = await browser.newContext();
+const possiblyOutdatedRules = [];
+const failedToLoad = [];
+
+try {
+  for (const [domain, filters] of Object.entries(sortedGroupedRules)) {
+    const url = `http://${domain}`;
+    console.log(`\nChecking domain: ${url}`);
+    const page = await context.newPage();
+    try {
+      await page.goto(url, { timeout: 30000, waitUntil: "load" });
+    } catch (error) {
+      console.error(`  - 🛑 Failed to load domain: ${domain}.`, error);
+      failedToLoad.push(url);
+      continue;
+    }
+
+    for (const filter of filters) {
+      const modifiedSelector = filter.selector.replaceAll(":-abp-has", ":has");
+
+      // TODO: Handle these rules. Playwright supports find by text: https://playwright.dev/docs/locators#filter-by-text
+      if (/-abp-contains|-abp-properties/.test(modifiedSelector)) {
+        console.warn(
+          `  - ⚠️ Skipping rule ${filter.rule} as it has unsupported ABP selector(s).`
+        );
+        continue;
+      }
+
+      try {
+        console.log(`  - Checking rule: ${filter.rule}`);
+        const elementCount = await page.locator(modifiedSelector).count();
+        if (elementCount === 0) {
+          console.warn(
+            `    ⚠️ No elements found for selector ${modifiedSelector} on domain: ${url}`
+          );
+          possiblyOutdatedRules.push(filter.rule);
+        } else {
+          console.log(
+            `    ✅ Found ${elementCount} elements for selector ${modifiedSelector} on domain: ${url}`
+          );
+        }
+      } catch (error) {
+        console.error(
+          `    🛑 Error checking rule ${filter.rule} on domain: ${url}`,
+          error
+        );
+        failedToLoad.push(url);
+      }
+    }
+
+    await page.close();
+  }
+} catch (error) {
+  console.error(error);
+} finally {
+  await browser.close();
+}
+
+if (possiblyOutdatedRules.length > 0) {
+  console.warn(
+    `\nPossibly outdated rules:\n\n${possiblyOutdatedRules.join("\n")}`
+  );
+}
+
+if (failedToLoad.length > 0) {
+  console.error(`\nFailed to load domains:\n\n${failedToLoad.join("\n")}`);
+}
+
+console.log(`\nALL DONE!`);

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "lint": "pnpm lint:ab && pnpm lint:md",
     "lint:ab": "aglint",
     "lint:md": "markdownlint .",
-    "prepare": "node .husky/install.js"
+    "prepare": "node .husky/install.js",
+    "check": "node assets/scripts/check.js"
   },
   "lint-staged": {
     "sections/**/*.txt": "aglint",
@@ -60,12 +61,14 @@
   },
   "devDependencies": {
     "@adguard/aglint": "^2.1.4",
+    "@adguard/agtree": "^3.1.3",
     "@adguard/dead-domains-linter": "^1.0.22",
     "dateformat": "^5.0.3",
     "husky": "^9.1.7",
     "lint-staged": "^15.5.1",
     "markdownlint": "^0.37.4",
-    "markdownlint-cli": "^0.44.0"
+    "markdownlint-cli": "^0.44.0",
+    "playwright": "^1.52.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@adguard/aglint':
         specifier: ^2.1.4
         version: 2.1.4
+      '@adguard/agtree':
+        specifier: ^3.1.3
+        version: 3.1.3
       '@adguard/dead-domains-linter':
         specifier: ^1.0.22
         version: 1.0.22
@@ -29,6 +32,9 @@ importers:
       markdownlint-cli:
         specifier: ^0.44.0
         version: 0.44.0
+      playwright:
+        specifier: ^1.52.0
+        version: 1.52.0
 
 packages:
 
@@ -44,6 +50,10 @@ packages:
   '@adguard/agtree@2.3.0':
     resolution: {integrity: sha512-MeaTncLxXh/ERIXYAOZMEG7TTtYfxyGPIwS4Eb6sqM3kvgaCsIKRAOEDqbMHaYrtR9KBX+l5MlsdTKdkaD3SgA==}
     engines: {node: '>=18'}
+
+  '@adguard/agtree@3.1.3':
+    resolution: {integrity: sha512-QQjCopTaFmI3Xhmbneq5BxooEftRqATD9r/4FhT7j9bLdmJB23iliUeoDysi5wyepueA1b0GNa9q2g8xce2lkg==}
+    engines: {node: '>=22'}
 
   '@adguard/css-tokenizer@1.2.0':
     resolution: {integrity: sha512-cUj5j/AU5z/T4//5M6KnIJBpykAY4QbDsoiQ2DaWX/r2XkepMkTb8DhIbUHJD/QLGEyLeQLpi+nlxAgf4NTRRQ==}
@@ -151,6 +161,14 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  camelcase-keys@7.0.2:
+    resolution: {integrity: sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==}
+    engines: {node: '>=12'}
+
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -324,6 +342,11 @@ packages:
     resolution: {integrity: sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==}
     engines: {node: '>=14.14'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -484,6 +507,10 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  map-obj@4.3.0:
+    resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
+    engines: {node: '>=8'}
 
   markdown-it@14.1.0:
     resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
@@ -660,9 +687,23 @@ packages:
     engines: {node: '>=0.10'}
     hasBin: true
 
+  playwright-core@1.52.0:
+    resolution: {integrity: sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.52.0:
+    resolution: {integrity: sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
+
+  quick-lru@5.1.1:
+    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
+    engines: {node: '>=10'}
 
   regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
@@ -810,6 +851,10 @@ packages:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
 
+  type-fest@1.4.0:
+    resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
+    engines: {node: '>=10'}
+
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
@@ -911,6 +956,18 @@ snapshots:
       semver: 7.7.1
       sprintf-js: 1.1.3
       tldts: 5.7.112
+      zod: 3.21.4
+
+  '@adguard/agtree@3.1.3':
+    dependencies:
+      '@adguard/css-tokenizer': 1.2.0
+      camelcase-keys: 7.0.2
+      clone-deep: 4.0.1
+      is-ip: 3.1.0
+      json5: 2.2.3
+      sprintf-js: 1.1.3
+      tldts: 5.7.112
+      xregexp: 5.1.1
       zod: 3.21.4
 
   '@adguard/css-tokenizer@1.2.0': {}
@@ -1046,6 +1103,15 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  camelcase-keys@7.0.2:
+    dependencies:
+      camelcase: 6.3.0
+      map-obj: 4.3.0
+      quick-lru: 5.1.1
+      type-fest: 1.4.0
+
+  camelcase@6.3.0: {}
 
   chalk@4.1.2:
     dependencies:
@@ -1191,6 +1257,9 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.1.0
       universalify: 2.0.1
+
+  fsevents@2.3.2:
+    optional: true
 
   get-caller-file@2.0.5: {}
 
@@ -1340,6 +1409,8 @@ snapshots:
       wrap-ansi: 9.0.0
 
   lru-cache@10.4.3: {}
+
+  map-obj@4.3.0: {}
 
   markdown-it@14.1.0:
     dependencies:
@@ -1619,7 +1690,17 @@ snapshots:
 
   pidtree@0.6.0: {}
 
+  playwright-core@1.52.0: {}
+
+  playwright@1.52.0:
+    dependencies:
+      playwright-core: 1.52.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
   punycode.js@2.3.1: {}
+
+  quick-lru@5.1.1: {}
 
   regenerator-runtime@0.14.1: {}
 
@@ -1744,6 +1825,8 @@ snapshots:
   tr46@0.0.3: {}
 
   type-fest@0.21.3: {}
+
+  type-fest@1.4.0: {}
 
   uc.micro@2.1.0: {}
 


### PR DESCRIPTION
Just put together a proof of concept of automating checking rules with Playwright (issue #576). It only parses the hufilter.txt file and only checks cosmetic filters against the site DOM when it is loaded. This is really far from an ideal solution, it just serves the purpose of showcasing my idea. 

## Problems encountered:

- Some sites have Cloudflare's anti-spam verification screen, which we probably cannot mitigate.
- There is a huge amount of warnings (not found DOM elements) raised during the script run. Need to check later with non-headless browser mode as to how many of them are false positives (e.g. is the site actually loads, is it a Cloudflare gate, etc)
- Due to the large number of warnings, the code probably has some issues querying the DOM (e.g. page did not load completely, race conditions, etc)
- Some domains could not be loaded within the timeout threshold (30 sec), so they were reported as dead sites, even ones that actually work. We should improve this. (like checking for both `http://` and `https://` URLs, or with and without `www.` prefix.

## TODO

- Improve code quality
- Check if chromium is the best browser engine for this
- Implement checking network filtering with Playwright request events
- Test rules with ABP specific syntax (like `:-abp-contains()`) - These need to be converted to match [Playwright's API](https://playwright.dev/docs/other-locators#css-locator) (like `:has-text()`)
- Include in CI

## To test the script:

```bash
pnpm install
pnpm exec playwright install
pnpm run build
pnpm run check
```

Fixes #576 when it's ready. I will improve this when I have more time.