### PR TITLE
foodker.hu

### DIFF
--- a/sections/adguard-specific/annoyances.txt
+++ b/sections/adguard-specific/annoyances.txt
@@ -23,7 +23,7 @@ fizz.hu#%#//scriptlet('set-cookie', 'gdpr_level', '1')
 hetek.hu#%#//scriptlet('remove-class', 'modal-open', 'body')
 hosszupuskasub.com#%#//scriptlet('prevent-window-open')
 kaveverzum.hu#$#body { position: static !important; }
-laptophardware.hu#%#//scriptlet('set-constant', 'cookie_alert_overlay', 'noopFunc')
+laptophardware.hu,milestone66.hu,reformsziget.hu,paplanvilag.hu,foodker.hu#%#//scriptlet('set-constant', 'cookie_alert_overlay', 'noopFunc')
 lifestory.hu#%#//scriptlet('remove-attr', 'oncontextmenu')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/128532
 magyarorszag.hu#%#//scriptlet('set-cookie', 'cookies_ok', '1')

--- a/sections/annoyances.txt
+++ b/sections/annoyances.txt
@@ -350,7 +350,6 @@ infostart.hu#?##sitemodal:-abp-has(.fb-button)
 /eu_rrf.jpg$image,domain=bme.hu
 /szechenyilogo.css$stylesheet,domain=bme.hu
 /eu_cookie_compliance.min.js$script,domain=bme.hu|unideb.hu
-/common_overlay.js$script,domain=milestone66.hu|reformsziget.hu
 /subscribePopup.js$script,domain=roadster.hu
 /otSDKStub.js$script,domain=tesco.hu
 ||cmp.quantcast.com^$script,domain=agrarszektor.hu|autoszektor.hu|bpiautosok.hu|g7.hu|hazipatika.com|hellovidek.hu|hrportal.hu|magyarnarancs.hu|index.hu|pestisracok.hu|portfolio.hu|telex.hu|totalcar.hu|totalbike.hu|szeretlekmagyarorszag.hu|port.hu|player.hu|mandiner.hu|budapestkornyeke.hu|bacsmegye.hu|civishir.hu|baon.hu|bama.hu|beol.hu|boon.hu|delmagyar.hu|duol.hu|feol.hu|kisalfold.hu|haon.hu|heol.hu|szoljon.hu|kemma.hu|nool.hu|sonline.hu|szon.hu|teol.hu|vaol.hu|veol.hu|zaol.hu|twice.hu|sassy.hu|prohardver.hu|mobilarena.hu|itcafe.hu|gamepod.hu|logout.hu|hardverapro.hu|pcwplus.hu|gsplus.hu|myonlineradio.hu|blikk.hu|medicalonline.hu

--- a/sections/ublock-origin-specific/annoyances.txt
+++ b/sections/ublock-origin-specific/annoyances.txt
@@ -24,7 +24,7 @@ help.semmelweis.hu#?#.modal:has(h3:has-text(Sütik használata)):has(button:has-
 hetek.hu##+js(rc, modal-open, body)
 hosszupuskasub.com##+js(window.open-defuser.js)
 kaveverzum.hu##body:style(position: static !important;)
-laptophardware.hu##+js(set, cookie_alert_overlay, noopFunc)
+laptophardware.hu,milestone66.hu,reformsziget.hu,paplanvilag.hu,foodker.hu##+js(set, cookie_alert_overlay, noopFunc)
 lifestory.hu##+js(ra, oncontextmenu)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/128532
 magyarorszag.hu##+js(rc, bottom-l, body, stay)


### PR DESCRIPTION
There was an overlay issue (other list blocked the cookie notice, but the page was not scrollable, and the shadow overlay stayed there.

The cookie overlay is defined in https://www.foodker.hu/!common_packages/jquery/own/shop_common/exploded/common_modal.js?mod_time=1748417327 but we can't block that file. So I decided to block the inline script that calls the function:

<img width="525" alt="image" src="https://github.com/user-attachments/assets/18f71f92-8ce0-4f2c-853e-81af5cb7cde2" />

Works with AdGuard and uBlock.