### PR TITLE
ingatlan.com self promo

### DIFF
--- a/sections/annoyances.txt
+++ b/sections/annoyances.txt
@@ -176,6 +176,7 @@ infostart.hu##.notification-popup
 infostart.hu###_ao-cmp-ui
 infostart.hu###ajanlo
 infostart.hu##div[data-qa="oil-Layer"]
+ingatlan.com###nps-form
 itthonrolhaza.hu###cookie-law-info-again
 itthonrolhaza.hu###cookie-law-info-bar
 jofogas.hu##.countdown-container

--- a/sections/selfpromo.txt
+++ b/sections/selfpromo.txt
@@ -31,6 +31,7 @@ drogriporter.hu###custom_html-20
 hang.hu##.widget-tamogatas-box
 ! https://github.com/hufilter/hufilter/issues/252
 infostart.hu##.article>.live-wrapper
+ingatlan.com##.estimate-promo-closable
 leet.hu###article + #offer
 leet.hu###Leet_cikk_normal_content_1 + section > p:last-of-type
 leet.hu###Leet_cikk_rectangle_right_1 + .featured-product


### PR DESCRIPTION
In #618 this rule was removed as it was ruled as useful content. But, there is a popup version of this on the search results page, which is very annoying. I suggest to remove that one at least.

Main page (blue box):

<img width="1490" height="750" alt="image" src="https://github.com/user-attachments/assets/f3eb5d1b-21ad-4381-ae58-f0ec2883e13d" />

Results page:

<img width="1492" height="754" alt="image" src="https://github.com/user-attachments/assets/bef448fe-0183-47ce-b651-e7e0343d0dd9" />

Especially distracting on mobile:

<img width="404" height="690" alt="image" src="https://github.com/user-attachments/assets/e8e6dcb6-006e-48bd-850e-91b799cd14c3" />

Just noticed the 1-10 feedback popup as well, hide that one too.
