### PR TITLE
Add cookie mask overlay element to filter list

### DIFF
--- a/sections/annoyances.txt
+++ b/sections/annoyances.txt
@@ -29,6 +29,7 @@ hu###cmplz-cookiebanner-container
 hu##app-cookie-layer
 hu###cookieConsent
 hu###overlay_cookie_alert
+hu##.cookie_overlay
 hu###szechenyi2020
 hu###szechenyi2020-wrapper
 hu###szechenyi


### PR DESCRIPTION
Some online stores (using UNAS e-commerce engine) display an #overlay_cookie_alert element, this element is often paired with a mask overlay .cookie_overlay for UI blocking purposes. This commit also hides the overlay so usability doesn't break.