### PR TITLE
Remove Ads on huntorrent.org and removed old hunhir.hu filter

### DIFF
--- a/sections/ads.txt
+++ b/sections/ads.txt
@@ -542,7 +542,8 @@ humormagazin.com##i > .recommendation-holder:nth-of-type(2)
 hungliaonline.com##.tqWLsnEEqeEw-bg
 hungliaonline.com##[style="background: rgb(255, 255, 255); max-width: 720px; z-index: 9999999; opacity: 1; visibility: visible;"]
 hungliaonline.com##[style="z-index: 999999; background: rgba(0, 0, 0, 0.85098); display: block;"]
-hunhir.hu##[class*="_ad"]
+huntorrent.org##.ads-container
+huntorrent.org##.banner-center
 hupont.hu##[id*="-reklam"]
 hupont.hu##[id*="fancybox"]
 hupont.hu##[id^="hirdetes_jobb_2"] + div + div


### PR DESCRIPTION
Removed hunhir.hu filters because website now redirects to hunhir.info, filter deprecated