### PR TITLE
mediamarkt.hu

### DIFF
--- a/sections/ads.txt
+++ b/sections/ads.txt
@@ -761,6 +761,9 @@ mandiner.hu##.real-estate-wrapper
 maszol.ro###article > section > div:not(.article_content)
 mavcsoport.hu###cboxOverlay
 mavcsoport.hu###colorbox
+mediamarkt.hu##article[data-cs-override-id^="mms-sponsored-product-card-"]
+mediamarkt.hu##aside[class="sc-a2fcee8-0 fmYGst"]:has(button[aria-label="Tudj meg többet a termékszponzorációról"])
+mediamarkt.hu##li[data-index-number]:has(button[aria-label="Tudj meg többet a termékszponzorációról"])
 medicalonline.hu##.ui-floating-message
 medicalonline.hu##.wsp-wrap
 medicalonline.hu##[class*="tBanner"]


### PR DESCRIPTION
`mediamarkt.hu##li[data-index-number]:has(button[aria-label="Tudj meg többet a termékszponzorációról"])` is intended for `https://www.mediamarkt.hu/`

`mediamarkt.hu##article[data-cs-override-id^="mms-sponsored-product-card-"]
mediamarkt.hu##aside[class="sc-a2fcee8-0 fmYGst"]:has(button[aria-label="Tudj meg többet a termékszponzorációról"])`
are intended for `https://www.mediamarkt.hu/hu/category/televizio-505010.html`