### PR TITLE
[megoldva] sötét módban használhatatlanok az oldalak: `molin-shop-ai`: ipon.hu, notebook.hu, benu.hu, euronics.hu, decathlon.hu, shop.biotechusa.hu

### DIFF
--- a/sections/ads.txt
+++ b/sections/ads.txt
@@ -606,7 +606,6 @@ ipon.hu##.u-hide\@mobile.flag-wrapper--fill.flag-wrapper.grid-col-lg-1-4.grid-co
 ipon.hu##[id*="banner"]
 ipon.hu###leftPoszter-section
 ipon.hu###salePoszter
-ipon.hu,notebook.hu,benu.hu,euronics.hu,decathlon.hu##molin-shop-ai
 ite.hu##div[class="tl-state-root tve-leads-ribbon tve-trigger-hide tve-tl-anim tve-leads-track-ribbon-1 tl-anim-slide_top tve-leads-triggered"]
 itmania.hu##.rckaexclude
 itmania.hu##[class*="hirdetes"]

--- a/sections/ads.txt
+++ b/sections/ads.txt
@@ -606,6 +606,7 @@ ipon.hu##.u-hide\@mobile.flag-wrapper--fill.flag-wrapper.grid-col-lg-1-4.grid-co
 ipon.hu##[id*="banner"]
 ipon.hu###leftPoszter-section
 ipon.hu###salePoszter
+ipon.hu,notebook.hu##molin-shop-ai
 ite.hu##div[class="tl-state-root tve-leads-ribbon tve-trigger-hide tve-tl-anim tve-leads-track-ribbon-1 tl-anim-slide_top tve-leads-triggered"]
 itmania.hu##.rckaexclude
 itmania.hu##[class*="hirdetes"]

--- a/sections/ads.txt
+++ b/sections/ads.txt
@@ -606,7 +606,7 @@ ipon.hu##.u-hide\@mobile.flag-wrapper--fill.flag-wrapper.grid-col-lg-1-4.grid-co
 ipon.hu##[id*="banner"]
 ipon.hu###leftPoszter-section
 ipon.hu###salePoszter
-ipon.hu,notebook.hu##molin-shop-ai
+ipon.hu,notebook.hu,benu.hu,euronics.hu,decathlon.hu##molin-shop-ai
 ite.hu##div[class="tl-state-root tve-leads-ribbon tve-trigger-hide tve-tl-anim tve-leads-track-ribbon-1 tl-anim-slide_top tve-leads-triggered"]
 itmania.hu##.rckaexclude
 itmania.hu##[class*="hirdetes"]

--- a/sections/annoyances.txt
+++ b/sections/annoyances.txt
@@ -17,6 +17,7 @@ hu###szechenyi-banner
 hu##.szechenyi2020-top-infoblokk
 hu##.sz2020-logo
 hu##molin-shop-ai
+hu###molin-chat-custom-button
 
 !-------------------------------------------------------------------------------!
 !------ Specific cosmetic filters ----------------------------------------------!

--- a/sections/annoyances.txt
+++ b/sections/annoyances.txt
@@ -111,6 +111,7 @@ infostart.hu###ajanlo
 infostart.hu###sitemodal:has(.fb-button)
 infostart.hu##div[data-qa="oil-Layer"]
 ingatlan.com###nps-form
+ipon.hu,notebook.hu,benu.hu,euronics.hu,decathlon.hu##molin-shop-ai
 keol.hu###social
 keol.hu##div.subscribe_module
 keol.hu##div[class="fb-like fb_iframe_widget"]

--- a/sections/annoyances.txt
+++ b/sections/annoyances.txt
@@ -16,6 +16,7 @@ hu###szechenyi_2020_logo
 hu###szechenyi-banner
 hu##.szechenyi2020-top-infoblokk
 hu##.sz2020-logo
+hu##molin-shop-ai
 
 !-------------------------------------------------------------------------------!
 !------ Specific cosmetic filters ----------------------------------------------!
@@ -111,7 +112,6 @@ infostart.hu###ajanlo
 infostart.hu###sitemodal:has(.fb-button)
 infostart.hu##div[data-qa="oil-Layer"]
 ingatlan.com###nps-form
-ipon.hu,notebook.hu,benu.hu,euronics.hu,decathlon.hu##molin-shop-ai
 keol.hu###social
 keol.hu##div.subscribe_module
 keol.hu##div[class="fb-like fb_iframe_widget"]


### PR DESCRIPTION
Én nem tudom mi ez, Dark Reader böngésző kiegészítő mellett ez az AI-s cucc ezt produkálja.
Az AI-s tag tiltása után teljesen jó az oldal.

https://github.com/user-attachments/assets/c42d0989-f28b-461c-839d-682ce1bbf11c

